### PR TITLE
Only use one Python version specifier in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
           python-version-file: "pyproject.toml"
 
       - name: 🔨 Install dependencies


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove hardcoded Python version and rely solely on the version specified in pyproject.toml for GitHub Actions workflow